### PR TITLE
Log an INFO message in `config_once` "happy path"

### DIFF
--- a/hg_agent_periodic/periodic.py
+++ b/hg_agent_periodic/periodic.py
@@ -170,8 +170,7 @@ def config_once(args):
         except:
             logging.exception('Writing & restarting: %s', args.diamond_config)
     else:
-        # No need to log the "happy path", but keep it for coverage & futures.
-        pass
+        logging.info('No change in Diamond configuration')
 
 
 def get_primary_ip():


### PR DESCRIPTION
For now, we're using the log messages from `periodic` as a signal for
whether all is well in `hg-agent`: if there are `ERROR` messages in the
last 10 lines or so, we say "not OK"; otherwise "OK".

An earlier pass removed "unnecessary" logging, with the result that when
everything's good, `periodic` logs are silent. This means we have
nothing to trigger the "OK" state anymore.

This message (re)introduces a "nothing to see here" log in the `config`
task. This is executed every 10s by default, whereas the `heartbeat`
task is executed every 60s.