### PR TITLE
update values present in config for the hg-agent metric forwarder

### DIFF
--- a/hg_agent_periodic/periodic.py
+++ b/hg_agent_periodic/periodic.py
@@ -76,7 +76,8 @@ schema = {
         },
         'spool_rotatesize': {
             'type': 'integer',
-            'description': "Max bytes for a spool file before rotation for the metric receivers"
+            'description': "Max bytes for a spool file before\
+                            rotation for the metric receivers"
         },
         'max_spool_count': {
             'type': 'integer',

--- a/hg_agent_periodic/periodic.py
+++ b/hg_agent_periodic/periodic.py
@@ -65,6 +65,22 @@ schema = {
             'type': 'string',
             'format': 'uri',
             'description': 'HTTP API endpoint for metric forwarder'
+        },
+        'tcp_port': {
+            'type': 'integer',
+            'description': "Port for TCP Metric Receiver to listen on"
+        },
+        'udp_port': {
+            'type': 'integer',
+            'description': "Port for UDP Metric Receiver to listen on"
+        },
+        'spool_rotatesize': {
+            'type': 'integer',
+            'description': "Max bytes for a spool file before rotation for the metric receivers"
+        },
+        'max_spool_count': {
+            'type': 'integer',
+            'description': 'Max number of spool files to keep on disk'
         }
     },
     'required': ['api_key',


### PR DESCRIPTION
adding:
```
tcp_port : port for the tcp metric recv to listen on.
udp_port: port for the udp metric recv to listen on.
spool_rotatesize: bytes written after which to rotate the spool file.
max_spool_count: max number of spool files to keep on disk.
```
version bump to hg-agent repo to follow this. 