### PR TITLE
Add `custom_prefix` and `hostname_method` options

### DIFF
--- a/hg_agent_periodic/config.py
+++ b/hg_agent_periodic/config.py
@@ -50,7 +50,7 @@ def main():
         logging.error('generating %s: %s', args.config, e)
     except (OSError, IOError) as e:
         logging.error('writing %s: %s', args.config, e)
-    except:
+    except Exception:
         logging.exception('unhandled exception')
 
 

--- a/hg_agent_periodic/diamond_config.py
+++ b/hg_agent_periodic/diamond_config.py
@@ -42,7 +42,7 @@ def main():
         logging.error('config in %s: %s', args.config, e)
     except (OSError, IOError) as e:
         logging.error('writing %s: %s', args.diamond_config, e)
-    except:
+    except Exception:
         logging.exception('unhandled exception')
 
 

--- a/hg_agent_periodic/periodic.py
+++ b/hg_agent_periodic/periodic.py
@@ -226,7 +226,7 @@ def config_once(args):
             with open(args.diamond_config, 'w') as f:
                 f.write(new_diamond)
             restart_diamond(args)
-        except:
+        except BaseException:
             logging.exception('Writing & restarting: %s', args.diamond_config)
     else:
         logging.info('No change in Diamond configuration')
@@ -336,7 +336,7 @@ def periodic_task(func, args, interval, shutdown):
         if now >= next_run:
             try:
                 func(args)
-            except:
+            except BaseException:
                 logging.exception('Unhandled exception in %s', func.__name__)
             next_run = now + interval
         time.sleep(1)

--- a/hg_agent_periodic/periodic.py
+++ b/hg_agent_periodic/periodic.py
@@ -119,6 +119,11 @@ schema = {
             'type': 'string',
             'description': 'Method to use for hostnames, per Diamond config'
         },
+        'heartbeat_url': {
+            'type': 'string',
+            'format': 'uri',
+            'description': 'Endpoint for Hosted Graphite heartbeat service'
+        },
     },
     'required': ['api_key',
                  'endpoint'],
@@ -324,7 +329,8 @@ def heartbeat_once(args):
     else:
         proxies = None
 
-    send_heartbeat(args.heartbeat, beat_data, proxies=proxies)
+    heartbeat_url = agent_config.get('heartbeat_url', args.heartbeat)
+    send_heartbeat(heartbeat_url, beat_data, proxies=proxies)
 
 
 def periodic_task(func, args, interval, shutdown):

--- a/hg_agent_periodic/periodic.py
+++ b/hg_agent_periodic/periodic.py
@@ -111,6 +111,14 @@ schema = {
                 'replset_node_name': {'type': 'string'},
             },
         },
+        'custom_prefix': {
+            'type': 'string',
+            'description': 'A custom prefix for metrics, instead of "hg_agent"'
+        },
+        'hostname_method': {
+            'type': 'string',
+            'description': 'Method to use for hostnames, per Diamond config'
+        },
     },
     'required': ['api_key',
                  'endpoint'],
@@ -297,11 +305,13 @@ def heartbeat_once(args):
     logs = collect_logs(args.periodic_logfile)
     messages = '\n'.join(logs)
 
+    hostname_method = agent_config.get('hostname_method', 'smart')
+
     beat_data = {
         'key': agent_config['api_key'],
         'timestamp': int(time.time()),
         'version': version,
-        'hostname': diamond.collector.get_hostname({}, method='smart'),
+        'hostname': diamond.collector.get_hostname({}, method=hostname_method),
         'ip': get_primary_ip(),
         'platform': platform.platform(),
         'ok': 'ERROR' not in messages,

--- a/hg_agent_periodic/templates/diamond.conf
+++ b/hg_agent_periodic/templates/diamond.conf
@@ -17,7 +17,8 @@ host = {{ endpoint }}
 
 [collectors]
 [[default]]
-path_prefix = {{ api_key }}.hg_agent
+path_prefix = {{ api_key }}.{{ custom_prefix|default('hg_agent') }}
+hostname_method = {{ hostname_method|default('smart') }}
 interval = 30
 
 [[CPUCollector]]

--- a/tests/test_hg_agent_periodic.py
+++ b/tests/test_hg_agent_periodic.py
@@ -123,6 +123,32 @@ class TestDiamondConfigGen(unittest.TestCase):
             'path_prefix = 00000000-0000-0000-0000-000000000000.hg_agent',
             lines)
 
+    def test_custom_prefix(self):
+        cfg = '''
+            api_key: "00000000-0000-0000-0000-000000000000"
+            endpoint: "localhost"
+            custom_prefix: "no_2_hg_agent"
+        '''
+        y = yaml.load(textwrap.dedent(cfg))
+        periodic.validate_agent_config(y)
+        diamond = periodic.gen_diamond_config(y)
+        lines = diamond.split('\n')
+        self.assertIn(
+            'path_prefix = 00000000-0000-0000-0000-000000000000.no_2_hg_agent',
+            lines)
+
+    def test_hostname_method(self):
+        cfg = '''
+            api_key: "00000000-0000-0000-0000-000000000000"
+            endpoint: "localhost"
+            hostname_method: "fqdn"
+        '''
+        y = yaml.load(textwrap.dedent(cfg))
+        periodic.validate_agent_config(y)
+        diamond = periodic.gen_diamond_config(y)
+        lines = diamond.split('\n')
+        self.assertIn('hostname_method = fqdn', lines)
+
     def test_generated_configs_differ(self):
         cfg1 = textwrap.dedent('''A line,
                                   a line we should ignore,


### PR DESCRIPTION
This exposes three new options in the agent's config file:

*  `hostname_method`
   Allows you to set the `diamond.conf` `hostname_method` variable
   directly, e.g. to `fqdn` to get `myhost_domain_com` rather than the
   default `smart` to get `myhost`.
   This affects both the diamond config generated & the data that is
   sent in `heartbeat` messages.

*  `custom_prefix`
   Allows you to set a prefix instead of `hg_agent`, if you so desire.
   This'll break e.g. auto dashboards but that's fine if it's what the
   you prefer.

* `heartbeat_url`
   Allows you to specify the URL that `heartbeat` messages are sent to,
   e.g. for dedicated cluster environments. This is already available via
   the `periodic` commandline, but that's awkward to use.

Also includes some lint fixes re: bare `except` statements.