### PR TITLE
Remove mandatory `endpoint` configuration

### DIFF
--- a/hg_agent_periodic/periodic.py
+++ b/hg_agent_periodic/periodic.py
@@ -54,7 +54,7 @@ schema = {
         'endpoint': {
             'type': 'string',
             'format': 'hostname',
-            'description': 'The user\'s HG carbon endpoint'
+            'description': 'Carbon endpoint for Diamond to send metrics to'
         },
         'https_proxy': {
             'type': 'string',
@@ -64,7 +64,7 @@ schema = {
         'endpoint_url': {
             'type': 'string',
             'format': 'uri',
-            'description': 'HTTP API endpoint for metric forwarder'
+            'description': 'HTTP API endpoint for metric forwarding to HG'
         },
         'tcp_port': {
             'type': 'integer',
@@ -125,8 +125,7 @@ schema = {
             'description': 'Endpoint for Hosted Graphite heartbeat service'
         },
     },
-    'required': ['api_key',
-                 'endpoint'],
+    'required': ['api_key'],
     'additionalProperties': False
 }
 

--- a/hg_agent_periodic/templates/diamond.conf
+++ b/hg_agent_periodic/templates/diamond.conf
@@ -13,7 +13,7 @@ log_file = /var/log/hg-agent/archive.log
 days = 7
 
 [[GraphiteHandler]]
-host = {{ endpoint }}
+host = {{ endpoint|default('localhost') }}
 
 [collectors]
 [[default]]


### PR DESCRIPTION
Originally, the Hosted Graphite agent required both an API key & a
specific `carbon` endpoint, e.g. `<uid>.carbon.hostedgraphite.com`. The
latter allowed us to manage routing for a particular user's Carbon data
via DNS.

When we added the local receiver & forwarder (i.e. buffering metric data
locally and then piping it up over the HTTP API):
  https://www.hostedgraphite.com/docs/agent/layout.html#metric-receiver
there was no longer any need to specify `endpoint` - in almost every
case it should be `localhost`.

This change removes & defaults the mandatory `endpoint` configuration
option. That in turn makes tests a little less verbose.