### PR TITLE
HTTP sink & heartbeat endpoints in config tool

### DIFF
--- a/hg_agent_periodic/config.py
+++ b/hg_agent_periodic/config.py
@@ -24,6 +24,12 @@ def get_args(argv=None):
     parser.add_argument('--endpoint',
                         default='localhost',
                         help='HG Agent local Graphite endpoint.')
+    parser.add_argument('--endpoint-url',
+                        default='',
+                        help='Hosted Graphite sink API endpoint.')
+    parser.add_argument('--heartbeat-url',
+                        default='',
+                        help='Hosted Graphite heartbeat metadata endpoint.')
     args = parser.parse_args(args=argv)
     return args
 
@@ -35,13 +41,12 @@ def main():
     try:
         agent_config = {
             'api_key': args.api_key,
-            'endpoint': args.endpoint,
-            'mongodb': {
-                'enabled': False,
-                'host': 'localhost',
-                'port': 27017,
-            },
         }
+        if args.endpoint_url:
+            agent_config['endpoint_url'] = args.endpoint_url
+        if args.heartbeat_url:
+            agent_config['heartbeat_url'] = args.heartbeat_url
+
         periodic.validate_agent_config(agent_config)
         data = yaml.dump(agent_config, default_flow_style=False)
         with open(args.config, 'w') as f:


### PR DESCRIPTION
The `hg-agent-config` tool writes simple default configurations for
the agent. It's main use is in the install script that customers can
download from Hosted Graphite.

Most customers only require an API key, but customers who have large
dedicated environments have different endpoints for both HTTP sink data
& `heartbeat` metadata.

This change makes it possible for the agent installer script to take
those differences into account.

Note that `endpoint` is being deprecated as a "primary" config option:
  https://github.com/hostedgraphite/hg-agent-periodic/pull/10

Also, since the Diamond configuration template takes into account the
case where a `mongodb` sub-configuration is not present, there's no need
to write it by default here.