### PR TITLE
Restart the forwarder & receiver on a changed API key

### DIFF
--- a/hg_agent_periodic/periodic.py
+++ b/hg_agent_periodic/periodic.py
@@ -236,7 +236,7 @@ def config_once(args):
 
     if old_config:
         if (config_changed(old_config, agent_config, 'endpoint_url') or
-            config_changed(old_config, agent_config, 'api_key')):
+                config_changed(old_config, agent_config, 'api_key')):
             restart_process(args, 'forwarder')
 
     new_diamond = gen_diamond_config(agent_config)

--- a/hg_agent_periodic/periodic.py
+++ b/hg_agent_periodic/periodic.py
@@ -237,8 +237,10 @@ def config_once(args):
     if old_config:
         if (config_changed(old_config, agent_config, 'endpoint_url') or
                 config_changed(old_config, agent_config, 'api_key')):
-            logging.info('Forwarder configuration changed, restarting.')
+            logging.info('Forwarder/receiver configuration changed, '
+                         'restarting.')
             restart_process(args, 'forwarder')
+            restart_process(args, 'receiver')
 
     new_diamond = gen_diamond_config(agent_config)
     try:

--- a/hg_agent_periodic/periodic.py
+++ b/hg_agent_periodic/periodic.py
@@ -237,6 +237,7 @@ def config_once(args):
     if old_config:
         if (config_changed(old_config, agent_config, 'endpoint_url') or
                 config_changed(old_config, agent_config, 'api_key')):
+            logging.info('Forwarder configuration changed, restarting.')
             restart_process(args, 'forwarder')
 
     new_diamond = gen_diamond_config(agent_config)

--- a/hg_agent_periodic/periodic.py
+++ b/hg_agent_periodic/periodic.py
@@ -224,6 +224,10 @@ def remember_config(new):
     old_config.update(new)
 
 
+def config_changed(cfg1, cfg2, key):
+    return cfg1.get(key) != cfg2.get(key)
+
+
 def config_once(args):
     '''Load config, gen diamond config, and restart diamond if changed.'''
     agent_config = load_config('config', args.config)
@@ -231,7 +235,8 @@ def config_once(args):
         return
 
     if old_config:
-        if old_config.get('endpoint_url') != agent_config.get('endpoint_url'):
+        if (config_changed(old_config, agent_config, 'endpoint_url') or
+            config_changed(old_config, agent_config, 'api_key')):
             restart_process(args, 'forwarder')
 
     new_diamond = gen_diamond_config(agent_config)

--- a/hg_agent_periodic/templates/diamond.conf
+++ b/hg_agent_periodic/templates/diamond.conf
@@ -17,7 +17,7 @@ host = {{ endpoint|default('localhost') }}
 
 [collectors]
 [[default]]
-path_prefix = {{ api_key }}.{{ custom_prefix|default('hg_agent') }}
+path_prefix = {{ custom_prefix|default('hg_agent') }}
 hostname_method = {{ hostname_method|default('smart') }}
 interval = 30
 

--- a/tests/test_hg_agent_periodic.py
+++ b/tests/test_hg_agent_periodic.py
@@ -264,7 +264,7 @@ class TestConfigOnce(fake_filesystem_unittest.TestCase):
     @mock.patch('hg_agent_periodic.periodic.restart_process')
     @mock.patch('hg_agent_periodic.periodic.gen_diamond_config')
     def test_config_changed_endpoint_url(self, mock_gen, mock_restart):
-        '''The forwarder is restarted with changed `endpoint_url`'''
+        '''The forwarder/receiver are restarted with changed `endpoint_url`'''
         mock_gen.return_value = 'a fake diamond config\n'
         self.fs.CreateFile('/hg-agent.cfg',
                            contents=textwrap.dedent('''
@@ -278,7 +278,8 @@ class TestConfigOnce(fake_filesystem_unittest.TestCase):
                                endpoint_url: "https://other-endpoint"
                             '''))
         periodic.config_once(ConfigArgs('/hg-agent.cfg', '/diamond.cfg'))
-        mock_restart.assert_called_with(mock.ANY, 'forwarder')
+        mock_restart.assert_any_call(mock.ANY, 'forwarder')
+        mock_restart.assert_any_call(mock.ANY, 'receiver')
 
     @mock.patch('hg_agent_periodic.periodic.restart_process')
     @mock.patch('hg_agent_periodic.periodic.gen_diamond_config')
@@ -296,7 +297,7 @@ class TestConfigOnce(fake_filesystem_unittest.TestCase):
     @mock.patch('hg_agent_periodic.periodic.restart_process')
     @mock.patch('hg_agent_periodic.periodic.gen_diamond_config')
     def test_config_changed_api_key(self, mock_gen, mock_restart):
-        '''The forwarder is restarted with changed `api_key`'''
+        '''The forwarder/receiver are restarted with changed `api_key`'''
         mock_gen.return_value = 'a fake diamond config\n'
         self.fs.CreateFile('/hg-agent.cfg',
                            contents=textwrap.dedent('''
@@ -308,7 +309,8 @@ class TestConfigOnce(fake_filesystem_unittest.TestCase):
                                api_key: "10000000-0000-0000-0000-000000000001"
                             '''))
         periodic.config_once(ConfigArgs('/hg-agent.cfg', '/diamond.cfg'))
-        mock_restart.assert_called_with(mock.ANY, 'forwarder')
+        mock_restart.assert_any_call(mock.ANY, 'forwarder')
+        mock_restart.assert_any_call(mock.ANY, 'receiver')
 
     @mock.patch('hg_agent_periodic.periodic.restart_process')
     @mock.patch('hg_agent_periodic.periodic.gen_diamond_config')
@@ -326,7 +328,7 @@ class TestConfigOnce(fake_filesystem_unittest.TestCase):
                                endpoint_url: "https://my-endpoint"
                             '''))
         periodic.config_once(ConfigArgs('/hg-agent.cfg', '/diamond.cfg'))
-        mock_restart.assert_called_with(mock.ANY, 'forwarder')
+        mock_restart.assert_any_call(mock.ANY, 'forwarder')
 
     @mock.patch('hg_agent_periodic.periodic.logging')
     @mock.patch('hg_agent_periodic.periodic.restart_process')

--- a/tests/test_hg_agent_periodic.py
+++ b/tests/test_hg_agent_periodic.py
@@ -123,7 +123,7 @@ class TestDiamondConfigGen(unittest.TestCase):
         lines = diamond.split('\n')
         self.assertIn('host = localhost', lines)
         self.assertIn(
-            'path_prefix = 00000000-0000-0000-0000-000000000000.hg_agent',
+            'path_prefix = hg_agent',
             lines)
 
     def test_custom_prefix(self):
@@ -136,7 +136,7 @@ class TestDiamondConfigGen(unittest.TestCase):
         diamond = periodic.gen_diamond_config(y)
         lines = diamond.split('\n')
         self.assertIn(
-            'path_prefix = 00000000-0000-0000-0000-000000000000.no_2_hg_agent',
+            'path_prefix = no_2_hg_agent',
             lines)
 
     def test_hostname_method(self):


### PR DESCRIPTION
Include `api_key` in the config values `forwarder` cares about, and since `receiver` does too, restart it as well.

While we're in the area, also tell Diamond it doesn't need the `api_key` anymore.